### PR TITLE
Remove ALIDNS_LINE_MAP

### DIFF
--- a/black_dnsync/dns_client.py
+++ b/black_dnsync/dns_client.py
@@ -272,19 +272,6 @@ class CloudxnsClient(BaseClient):
             data['mx'] = record.priority
         return self.__request('PUT', uri, data)
 
-
-ALIDNS_LINE_MAP = {
-    'default': 'default',
-    'ct': 'telecom',
-    'cu': 'unicom',
-    'cm': 'mobile',
-    'edu': 'edu',
-    'oversea': 'oversea',
-}
-
-ALIDNS_LINE_MAP_REV = {v: k for k, v in ALIDNS_LINE_MAP.items()}
-
-
 class AliyunClient(BaseClient):
     def __init__(self, api_key, api_secret):
         super(AliyunClient, self).__init__(api_key, api_secret)
@@ -342,7 +329,7 @@ class AliyunClient(BaseClient):
             raise ValueError('Do not support Aliyun DNS record disabled status!')
 
         try:
-            line = ALIDNS_LINE_MAP_REV[record['Line']]
+            line = record['Line']
         except KeyError:
             raise UnsupportedLineError(record)
 
@@ -381,7 +368,7 @@ class AliyunClient(BaseClient):
             'Value': record.value,
             'TTL': record.ttl,
         }
-        data['Line'] = ALIDNS_LINE_MAP[record.line]
+        data['Line'] = record.line
         if record.type == 'MX':
             data['Priority'] = record.priority
         return self.__request(data)
@@ -402,7 +389,7 @@ class AliyunClient(BaseClient):
             'Value': record.value,
             'TTL': record.ttl,
         }
-        data['Line'] = ALIDNS_LINE_MAP[record.line]
+        data['Line'] = record.line
         if record.type == 'MX':
             data['Priority'] = record.priority
         return self.__request(data)

--- a/black_dnsync/dns_client.py
+++ b/black_dnsync/dns_client.py
@@ -32,13 +32,6 @@ class APIError(Exception):
         return repr(self.msg)
 
 
-class UnsupportedLineError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
-    def __str__(self):
-        return repr(self.msg)
-
-
 class BaseClient(object):
 
     def __init__(self, api_key, api_secret):
@@ -328,10 +321,8 @@ class AliyunClient(BaseClient):
         if record['Status'] == 'Disable':
             raise ValueError('Do not support Aliyun DNS record disabled status!')
 
-        try:
-            line = record['Line']
-        except KeyError:
-            raise UnsupportedLineError(record)
+
+        line = record['Line']
 
         priority = None
         if record['Type'] == 'MX':


### PR DESCRIPTION
Aliyun has supported more types of resolution line enumeration than before. ALIDNS_LINE_MAP is not updated with the latest. Please refer to: https://help.aliyun.com/document_detail/29807.html

If the Aliyun DNS is configured with a resolution line other than the ones populated in `ALIDNS_LINE_MAP`, such as `os_euro_gb` in the example below, `black_dnsync.dns_client.AliyunClient#__to_record` throws out `UnsupportedLineError`.

```
  File "/vagrant/black_dnsync/main.py", line 116, in <module>
    main()
  File "/vagrant/black_dnsync/main.py", line 57, in main
    records = client.list_records(domain)
  File "/vagrant/black_dnsync/dns_client.py", line 368, in list_records
    record = self.__to_record(r)
  File "/vagrant/black_dnsync/dns_client.py", line 347, in __to_record
    raise UnsupportedLineError(record)
dns_client.UnsupportedLineError: {u'Status': u'ENABLE', u'Locked': False, u'RR': u'biz', u'Weight': 1, u'DomainName': u'example.com', u'RecordId': u'XXXXXXXXXXXXXXXX', u'Value': u'XXX.XX.XXX.XXX', u'TTL': 600, u'Line': u'os_euro_gb', u'Type': u'A'}
```


If we update `ALIDNS_LINE_MAP` with the enumeration provided by Aliyun, it will become bulged with hundreds of lines. It's unmaintainable as Aliyun regularly update their APIs.

IMHO we could delegate the responsibility to check the validity of resolution line enumeration to Aliyun DNS API instead, thus relieve the burden from black-dnsync. 

Aliyun DNS API comes with request parameter validation and responds with `SubDomainInvalid.Line` if the resolution line parameter is invalid.

```
  File "/vagrant/black_dnsync/main.py", line 116, in <module>
    main()
  File "/vagrant/black_dnsync/main.py", line 111, in main
    client.add_record(cfg['domain'], record)
  File "/vagrant/black_dnsync/dns_client.py", line 372, in add_record
    return self.__request(data)
  File "/vagrant/black_dnsync/dns_client.py", line 323, in __request
    raise APIError(r_json)
dns_client.APIError: {u'Code': u'SubDomainInvalid.Line', u'Message': u'Invalid line.', u'HostId': u'dns.aliyuncs.com', u'RequestId': u'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'}
```

However, removing `UnsupportedLineError` present the risk of failing amid record updating and committing only partial changes to Aliyun.

```
Records to Update:
@ A 192.168.1.25 ttl=600 => @ A 1.1.1.1 ttl=600

Records to Remove:
www A 192.168.1.25 ttl=600
*.blog A 192.168.1.99 ttl=600

Records to Add:
@ MX mxa.mailgun.org ttl=600 priority=10
@ MX mxb.mailgun.org ttl=600 priority=10
@ TXT "v=spf1 include:mailgun.ors ~all" ttl=600
www A hk-ali01 ttl=120 line=mumblejumble

Submit changes? [Y/N]Y
Y
Updating... @ A 192.168.1.25 ttl=600 => @ A 1.1.1.1 ttl=600
Done
www A 192.168.1.25 ttl=600
Removing... www A 192.168.1.25 ttl=600
Done
*.blog A 192.168.1.99 ttl=600
Removing... *.blog A 192.168.1.99 ttl=600
Done
Adding... @ MX mxa.mailgun.org ttl=600 priority=10
Done
Adding... @ MX mxb.mailgun.org ttl=600 priority=10
Done
Adding... @ TXT "v=spf1 include:mailgun.ors ~all" ttl=600
Done
Adding... www A hk-ali01 ttl=120 line=mumblejumble
Traceback (most recent call last):
  File "/vagrant/black_dnsync/main.py", line 116, in <module>
    main()
  File "/vagrant/black_dnsync/main.py", line 111, in main
    client.add_record(cfg['domain'], record)
  File "/vagrant/black_dnsync/dns_client.py", line 372, in add_record
    return self.__request(data)
  File "/vagrant/black_dnsync/dns_client.py", line 323, in __request
    raise APIError(r_json)
dns_client.APIError: {u'Code': u'SubDomainInvalid.Line', u'Message': u'Invalid line.', u'HostId': u'dns.aliyuncs.com', u'RequestId': u'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'}
```

Notice that `line=mumblejumble` is invalid thus interrupts the updating process with `APIError`.

Other DNS providers (DNSPod, DNSimple, CloudXNS) are not taken into account yet.